### PR TITLE
Bumped main dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,14 +3111,24 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001239",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-            "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+            "version": "1.0.30001629",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+            "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
             "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ]
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -16814,9 +16824,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001239",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-            "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+            "version": "1.0.30001629",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+            "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
             "dev": true
         },
         "chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@fortawesome/free-solid-svg-icons": "^5.15.3",
-                "@vidhill/fortawesome-11ty-shortcode-helper": "^1.0.1"
+                "@vidhill/fortawesome-11ty-shortcode-helper": "^1.1.0"
             },
             "devDependencies": {
                 "@babel/cli": "^7.12.1",
@@ -774,13 +774,22 @@
             }
         },
         "node_modules/@fortawesome/fontawesome-svg-core": {
-            "version": "1.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-            "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
             "hasInstallScript": true,
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "6.5.2"
             },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
+            "hasInstallScript": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2110,11 +2119,14 @@
             }
         },
         "node_modules/@vidhill/fortawesome-11ty-shortcode-helper": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@vidhill/fortawesome-11ty-shortcode-helper/-/fortawesome-11ty-shortcode-helper-1.0.2.tgz",
-            "integrity": "sha512-GHtbw1gOz/CUM+ttmBQHj97SYyDAC0tCyiXLXz/3HCIwibj1U9U6mC3aZaMjqKCmUpZa4+SarbUNF+NPXKhcaQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@vidhill/fortawesome-11ty-shortcode-helper/-/fortawesome-11ty-shortcode-helper-1.1.0.tgz",
+            "integrity": "sha512-YzPnvo7Jmzaq3G8B/zOZ3+oqbsCiffyDExs9wsr+4t1jQFQhJiPEj2oRj9MxmPJsaaMcKGuqz18jtSHEevolhQ==",
             "dependencies": {
-                "@fortawesome/fontawesome-svg-core": "^1.2.35"
+                "@fortawesome/fontawesome-svg-core": "^6.5.2"
+            },
+            "engines": {
+                "node": ">=18.16.1"
             }
         },
         "node_modules/abab": {
@@ -15056,11 +15068,18 @@
             "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
         },
         "@fortawesome/fontawesome-svg-core": {
-            "version": "1.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-            "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            },
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+                    "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw=="
+                }
             }
         },
         "@fortawesome/free-solid-svg-icons": {
@@ -16076,11 +16095,11 @@
             }
         },
         "@vidhill/fortawesome-11ty-shortcode-helper": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@vidhill/fortawesome-11ty-shortcode-helper/-/fortawesome-11ty-shortcode-helper-1.0.2.tgz",
-            "integrity": "sha512-GHtbw1gOz/CUM+ttmBQHj97SYyDAC0tCyiXLXz/3HCIwibj1U9U6mC3aZaMjqKCmUpZa4+SarbUNF+NPXKhcaQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@vidhill/fortawesome-11ty-shortcode-helper/-/fortawesome-11ty-shortcode-helper-1.1.0.tgz",
+            "integrity": "sha512-YzPnvo7Jmzaq3G8B/zOZ3+oqbsCiffyDExs9wsr+4t1jQFQhJiPEj2oRj9MxmPJsaaMcKGuqz18jtSHEevolhQ==",
             "requires": {
-                "@fortawesome/fontawesome-svg-core": "^1.2.35"
+                "@fortawesome/fontawesome-svg-core": "^6.5.2"
             }
         },
         "abab": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
-                "@fortawesome/free-solid-svg-icons": "^5.15.3",
+                "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@vidhill/fortawesome-11ty-shortcode-helper": "^1.1.0"
             },
             "devDependencies": {
@@ -765,9 +765,9 @@
             }
         },
         "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-            "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
             "hasInstallScript": true,
             "engines": {
                 "node": ">=6"
@@ -785,22 +785,13 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
-            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
-            "hasInstallScript": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@fortawesome/free-solid-svg-icons": {
-            "version": "5.15.3",
-            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
-            "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
+            "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
             "hasInstallScript": true,
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "6.5.2"
             },
             "engines": {
                 "node": ">=6"
@@ -15063,9 +15054,9 @@
             }
         },
         "@fortawesome/fontawesome-common-types": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-            "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw=="
         },
         "@fortawesome/fontawesome-svg-core": {
             "version": "6.5.2",
@@ -15073,21 +15064,14 @@
             "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
             "requires": {
                 "@fortawesome/fontawesome-common-types": "6.5.2"
-            },
-            "dependencies": {
-                "@fortawesome/fontawesome-common-types": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
-                    "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw=="
-                }
             }
         },
         "@fortawesome/free-solid-svg-icons": {
-            "version": "5.15.3",
-            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
-            "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
+            "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "6.5.2"
             }
         },
         "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     },
     "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
-        "@vidhill/fortawesome-11ty-shortcode-helper": "^1.0.1"
+        "@vidhill/fortawesome-11ty-shortcode-helper": "^1.1.0"
     },
     "publishConfig": {
         "access": "public"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "watch": "^0.13.0"
     },
     "dependencies": {
-        "@fortawesome/free-solid-svg-icons": "^5.15.3",
+        "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@vidhill/fortawesome-11ty-shortcode-helper": "^1.1.0"
     },
     "publishConfig": {


### PR DESCRIPTION
Bumped caniusedb, the helper tool, and the font itself.

[See my comment on the other pull request regarding updating further dependencies for you](https://github.com/vidhill/fortawesome-regular-svg-11ty-shortcode/pull/8). :)